### PR TITLE
Add support to year with two digits

### DIFF
--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -75,6 +75,13 @@ defmodule Mail.Parsers.RFC2822 do
   end
 
   def erl_from_timestamp(
+        <<date::binary-size(2), "-", month::binary-size(3), "-", year::binary-size(2),
+          rest::binary>>
+      ) do
+    erl_from_timestamp("#{date} #{month} #{year}#{rest}")
+  end
+
+  def erl_from_timestamp(
         <<date::binary-size(11), " ", hour::binary-size(2), ":", minute::binary-size(2), " ",
           rest::binary>>
       ) do
@@ -103,9 +110,28 @@ defmodule Mail.Parsers.RFC2822 do
       {{year, month, date}, {hour, minute, second}}
     end
 
+    # Example: 15 Feb 24 11:10:55 +0000
     def erl_from_timestamp(
-          <<date::binary-size(2), " ", month::binary-size(unquote(month_size)), " ", year::binary-size(4), " ",
-            hour::binary-size(2), ":", minute::binary-size(2), ":", second::binary-size(2)>>
+          <<date::binary-size(2), " ", month::binary-size(unquote(month_size)), " ",
+            year::binary-size(2), " ", hour::binary-size(2), ":", minute::binary-size(2), ":",
+            second::binary-size(2), " ", _timezone::binary-size(5), _rest::binary>>
+        ) do
+      year = "20#{year}" |> String.to_integer()
+      month_name = String.downcase(month)
+      month = get_month_number(month_name)
+      date = date |> String.to_integer()
+
+      hour = hour |> String.to_integer()
+      minute = minute |> String.to_integer()
+      second = second |> String.to_integer()
+
+      {{year, month, date}, {hour, minute, second}}
+    end
+
+    def erl_from_timestamp(
+          <<date::binary-size(2), " ", month::binary-size(unquote(month_size)), " ",
+            year::binary-size(4), " ", hour::binary-size(2), ":", minute::binary-size(2), ":",
+            second::binary-size(2)>>
         ) do
       erl_from_timestamp("#{date} #{month} #{year} #{hour}:#{minute}:#{second} (+00:00)")
     end
@@ -113,9 +139,9 @@ defmodule Mail.Parsers.RFC2822 do
     # This adds support for a now obsolete format
     # https://tools.ietf.org/html/rfc2822#section-4.3
     def erl_from_timestamp(
-          <<date::binary-size(2), " ", month::binary-size(unquote(month_size)), " ", year::binary-size(4), " ",
-            hour::binary-size(2), ":", minute::binary-size(2), ":", second::binary-size(2), " ",
-            timezone::binary-size(3), _rest::binary>>
+          <<date::binary-size(2), " ", month::binary-size(unquote(month_size)), " ",
+            year::binary-size(4), " ", hour::binary-size(2), ":", minute::binary-size(2), ":",
+            second::binary-size(2), " ", timezone::binary-size(3), _rest::binary>>
         ) do
       erl_from_timestamp("#{date} #{month} #{year} #{hour}:#{minute}:#{second} (#{timezone})")
     end
@@ -123,9 +149,9 @@ defmodule Mail.Parsers.RFC2822 do
     # This adds support for a now obsolete format (with obsolete timezone, UT)
     # https://tools.ietf.org/html/rfc2822#section-4.3
     def erl_from_timestamp(
-          <<date::binary-size(2), " ", month::binary-size(unquote(month_size)), " ", year::binary-size(4), " ",
-            hour::binary-size(2), ":", minute::binary-size(2), ":", second::binary-size(2), " ",
-            "UT", _rest::binary>>
+          <<date::binary-size(2), " ", month::binary-size(unquote(month_size)), " ",
+            year::binary-size(4), " ", hour::binary-size(2), ":", minute::binary-size(2), ":",
+            second::binary-size(2), " ", "UT", _rest::binary>>
         ) do
       erl_from_timestamp("#{date} #{month} #{year} #{hour}:#{minute}:#{second} (+00:00)")
     end

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -159,7 +159,7 @@ defmodule Mail.Parsers.RFC2822Test do
     assert erl_from_timestamp("14 Jun 2019 11:24 +0000") == {{2019, 6, 14}, {11, 24, 0}}
     assert erl_from_timestamp("28 JUN 2021 09:10 +0200") == {{2021, 6, 28}, {9, 10, 0}}
     assert erl_from_timestamp("12 May 2020 12:08:24 UT") == {{2020, 5, 12}, {12, 8, 24}}
-
+    assert erl_from_timestamp("15 Feb 24 11:10:55 +0000") == {{2024, 2, 15}, {11, 10, 55}}
   end
 
   test "erl_from_timestamp\1 with invalid RFC2822 timestamps (found in the wild)" do
@@ -167,7 +167,9 @@ defmodule Mail.Parsers.RFC2822Test do
 
     assert erl_from_timestamp("Thu, 16 May 2019 5:50:53 +0700") == {{2019, 5, 16}, {5, 50, 53}}
     assert erl_from_timestamp("28/08/2023 20:20:02") == {{2023, 8, 28}, {20, 20, 2}}
-    assert erl_from_timestamp("Fri, 15 September 2023 02:16:52 +0000 (UTC)") == {{2023, 9, 15}, {2, 16, 52}}
+
+    assert erl_from_timestamp("Fri, 15 September 2023 02:16:52 +0000 (UTC)") ==
+             {{2023, 9, 15}, {2, 16, 52}}
   end
 
   test "parse_recipient_value retrieves a list of name and addresses" do


### PR DESCRIPTION
## Problema

O parser não consegue lidar com ano de dois dígitos, exemplo: `15 Feb 24 11:10:55 +0000`

## Solução

Dando suporte ao parser para lidar com dois dígitos do campo `year`