### PR TITLE
Remove warning change config module and change get to compile

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -22,7 +22,7 @@ defmodule Mail.Renderers.RFC2822 do
   @address_types ["From", "To", "Reply-To", "Cc", "Bcc"]
 
   # https://tools.ietf.org/html/rfc2822#section-3.4.1
-  @email_validation_regex Application.get_env(
+  @email_validation_regex Application.compile_env(
                             :mail,
                             :email_regex,
                             ~r/[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,64}/


### PR DESCRIPTION
## Problema

Estamos recebendo warning em relação ao uso do módulo `use Config`
Estamos recebendo warning em relação a utilização do `Application.get_env`

## solucao

- Trocar `use Config` por `import Config`
- Trocar `Application.get_env` por `Application.compile_env`